### PR TITLE
Adds logic to filter unregistered intents

### DIFF
--- a/rasa/core/channels/telegram.py
+++ b/rasa/core/channels/telegram.py
@@ -241,7 +241,7 @@ class TelegramInput(InputChannel):
                 metadata = self.get_metadata(request)
                 
                 if self.allowed_slash_intents is not None:
-                    intent_name = re.findall(r'^/([a-zA-Z0-9]+)', text)
+                    intent_name = re.findall(r'^/([a-zA-Z0-9_.]+)', text)
                     if bool(intent_name) and (intent_name[0] not in self.allowed_slash_intents):
                         text = text[1:]
 


### PR DESCRIPTION
Get a list of registered / allowed intents from credentials. If we have a list, check any slash messages from telegram are in the allow list. If not, remove the slash from the front and process normally. 

This relates to enhancement request over here: https://github.com/RasaHQ/rasa/issues/11021

**Status (please check what you already did)**:
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog (please check [changelog](https://github.com/RasaHQ/rasa/tree/main/changelog) for instructions)
- [ ] reformat files using `black` (please check [Readme](https://github.com/RasaHQ/rasa#code-style) for instructions)
